### PR TITLE
Remove DEBUG by default

### DIFF
--- a/flask_allowed_hosts/helpers.py
+++ b/flask_allowed_hosts/helpers.py
@@ -5,7 +5,7 @@ from typing import List, Union, Callable, Any
 
 from flask import request
 
-DEBUG = os.environ.get("ALLOWED_HOSTS_DEBUG", "False") == "False"
+DEBUG = os.environ.get("ALLOWED_HOSTS_DEBUG", "False") != "False"
 LOCAL_HOST_VARIANTS = ('localhost', '127.0.0.1', '::1')
 
 


### PR DESCRIPTION
See #6

```
(.venv) nicco@denkbuch:~/open-web-calendar$ echo $ALLOWED_HOSTS_DEBUG

(.venv) nicco@denkbuch:~/open-web-calendar$ python
Python 3.11.6 (main, Oct 23 2023, 13:38:18) [GCC 13.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import flask_allowed_hosts
>>> import flask_allowed_hosts.helpers
>>> flask_allowed_hosts.helpers.DEBUG
True
>>> import os
>>> os.environ.get("ALLOWED_HOSTS_DEBUG", "False")
'False'
>>> os.environ.get("ALLOWED_HOSTS_DEBUG", "False") == "False"
True

```